### PR TITLE
Make sure that the zero chunk is actually sent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,6 @@ const spec = {
   },
 };
 
-spec.stream = {
-  events: spec.readable.events.concat(spec.writable.events),
-  methods: spec.readable.methods.concat(spec.writable.methods),
-};
-
 const patch = (res) => {
   debug('patching res');
 
@@ -53,16 +48,23 @@ const patch = (res) => {
   const _write = res.write.bind(res);
   const _emit = res.emit.bind(res);
 
-  let lastStream = res;
-
   const resProxy = new stream.Writable();
   resProxy.write = _write;
   resProxy.end = _end;
 
-  // Redirect events:
-  // 1) pass-xyz => res.emit(xyz)
-  // 2) writable events => resProxy.emit(event)
-  // 3) other events => res.emit(event)
+  /*
+   * Events emitted by the PassThrough stream (i.e. "pass-*") will be
+   * re-emitted by the ServerResponse. However, the "pass-finish" event
+   * is not re-emitted, as this causes the ServerResponse to remove its
+   * connection socket (see NodeJS _http_socket.js), which in turn prevents it from
+   * sending the zero chunk (within ServerResponse.end). The ServerResponse
+   * does however emit its own "finish" event later on.
+   *
+   * Writable events will be emitted by resProxy.
+   *
+   * All other events (e.g. custom), will be emitted by the ServerResponse,
+   * as expected.
+   */
   res.emit = (evName, ...args) => {
     const matches = evName.match(/^pass\-(.*)/);
     const isWritableEvent = spec.writable.events.indexOf(evName) !== -1;
@@ -70,6 +72,10 @@ const patch = (res) => {
     if (matches) {
       const name = matches[1];
       debug(`emitting ${name} to res`);
+
+      if (name === 'finish') {
+        return false;
+      }
       return _emit(name, ...args);
     } else if (isWritableEvent) {
       debug(`emitting ${evName} to resProxy`);
@@ -82,22 +88,23 @@ const patch = (res) => {
   const pass = new stream.PassThrough();
 
   // Forward res stream methods to pass
-  spec.stream.methods.forEach((methodName) => {
+  spec.writable.methods.forEach((methodName) => {
     res[methodName] = pass[methodName].bind(pass);
   });
 
   // Forward pass stream events to res
-  spec.stream.events.forEach((evName) => {
+  spec.writable.events.forEach((evName) => {
     pass.on(evName, (...args) => res.emit('pass-' + evName, ...args));
   });
+
+  let lastStream = pass;
+  lastStream.pipe(resProxy);
 
   res.transform = (s) => {
     lastStream.unpipe(resProxy);
     lastStream.pipe(s).pipe(resProxy);
     lastStream = s;
   };
-
-  res.pipe(resProxy);
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 import test from 'blue-tape';
 import http from 'http';
 import express from 'express';
-import fetch from 'node-fetch';
+import _fetch from 'node-fetch';
 import transform from '../src';
 import zlib from 'zlib';
 import onHeaders from 'on-headers';
@@ -68,6 +68,11 @@ const tearDown = () => {
   return Promise.resolve();
 };
 
+// add a default timeout of 1s
+const fetch = (url, options = {}) => {
+  return _fetch(url, Object.assign({}, { timeout: 1000 }, options));
+};
+
 let url;
 test('start server', (t) => {
   return setup().then((r) => {
@@ -77,7 +82,7 @@ test('start server', (t) => {
 });
 
 test('/hello?gzip', (t) => {
-  return fetch(`${url}/hello`)
+  return fetch(`${url}/hello?gzip`)
     .then((res) => res.text())
     .then((body) => {
       t.equal(body, 'Hello World!');
@@ -85,7 +90,7 @@ test('/hello?gzip', (t) => {
 });
 
 test('res.json?gzip', (t) => {
-  return fetch(`${url}/json`)
+  return fetch(`${url}/json?gzip`)
     .then((res) => {
       return res.json();
     })
@@ -147,4 +152,3 @@ test('fsblobstore', (t) => {
 test('stop server', () => {
   return tearDown();
 });
-


### PR DESCRIPTION
It appears that emitting the "finish" event on the original response object causes it to lose its socket connection (see [_http_server.js](https://github.com/nodejs/node/blob/1170b262613d8afe6dc6081d1072ce6180512bfb/lib/_http_server.js#L505)). This can be checked for example by requesting any resource from a server using the transform with `curl --raw`, which will complain with `curl: (18) transfer closed with outstanding read data remaining`. With no connection, `res` can't send the zero chunk (for chunked-encoded connections, which is the default afaik), on the "end" event. Hence I don't forward the "finish" event to `res`.

I also noticed that the tests did not actually use the gzip-transform (because the URLs were missing the `?gzip` query). If it is added, the tests fail due to the above problem.

As the `ServerResponse` as well as `resProxy` are instances of `Stream.Writable`, forwarding read-events doesn't really make sense, so I removed those (also, `res` doesn't need the readable methods of `pass`).
